### PR TITLE
JS-7167 Add fcm api support

### DIFF
--- a/lib/rpush/client/active_model.rb
+++ b/lib/rpush/client/active_model.rb
@@ -19,6 +19,11 @@ require 'rpush/client/active_model/adm/data_validator'
 require 'rpush/client/active_model/adm/app'
 require 'rpush/client/active_model/adm/notification'
 
+require 'rpush/client/active_model/fcm/expiry_collapse_key_mutual_inclusion_validator'
+require 'rpush/client/active_model/fcm/notification_keys_in_allowed_list_validator'
+require 'rpush/client/active_model/fcm/app'
+require 'rpush/client/active_model/fcm/notification'
+
 require 'rpush/client/active_model/gcm/expiry_collapse_key_mutual_inclusion_validator'
 require 'rpush/client/active_model/gcm/app'
 require 'rpush/client/active_model/gcm/notification'

--- a/lib/rpush/client/active_model/fcm/app.rb
+++ b/lib/rpush/client/active_model/fcm/app.rb
@@ -1,0 +1,20 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Fcm
+        module App
+          def self.included(base)
+            base.instance_eval do
+              # TODO: Add whatever validation is needed here
+              # validates :auth_key, presence: true
+            end
+          end
+
+          def service_name
+            'fcm'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/fcm/app.rb
+++ b/lib/rpush/client/active_model/fcm/app.rb
@@ -5,8 +5,7 @@ module Rpush
         module App
           def self.included(base)
             base.instance_eval do
-              # TODO: Add whatever validation is needed here
-              # validates :auth_key, presence: true
+              validates :fcm_json_token, presence: true
             end
           end
 

--- a/lib/rpush/client/active_model/fcm/expiry_collapse_key_mutual_inclusion_validator.rb
+++ b/lib/rpush/client/active_model/fcm/expiry_collapse_key_mutual_inclusion_validator.rb
@@ -1,0 +1,14 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Fcm
+        class ExpiryCollapseKeyMutualInclusionValidator < ::ActiveModel::Validator
+          def validate(record)
+            return unless record.collapse_key && !record.expiry
+            record.errors.add :expiry, 'must be set when using a collapse_key'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -1,0 +1,111 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Fcm
+        module Notification
+          FCM_PRIORITY_HIGH = Rpush::Client::ActiveModel::Apns::Notification::APNS_PRIORITY_IMMEDIATE
+          FCM_PRIORITY_NORMAL = Rpush::Client::ActiveModel::Apns::Notification::APNS_PRIORITY_CONSERVE_POWER
+          FCM_PRIORITIES = [FCM_PRIORITY_HIGH, FCM_PRIORITY_NORMAL]
+
+          ROOT_NOTIFICATION_KEYS = %w[title body image].freeze
+          ANDROID_NOTIFICATION_KEYS = %w[icon tag color click_action body_loc_key body_loc_args title_loc_key
+                                         title_loc_args channel_id ticker sticky event_time local_only
+                                         default_vibrate_timings default_light_settings vibrate_timings
+                                         visibility notification_count light_settings].freeze
+
+          def self.included(base)
+            base.instance_eval do
+              validates :device_token, presence: true
+              validates :priority, inclusion: { in: FCM_PRIORITIES }, allow_nil: true
+
+              validates_with Rpush::Client::ActiveModel::PayloadDataSizeValidator, limit: 4096
+              validates_with Rpush::Client::ActiveModel::RegistrationIdsCountValidator, limit: 1000
+
+              validates_with Rpush::Client::ActiveModel::Fcm::ExpiryCollapseKeyMutualInclusionValidator
+              validates_with Rpush::Client::ActiveModel::Fcm::NotificationKeysInAllowedListValidator
+            end
+          end
+
+          def payload_data_size
+            multi_json_dump(as_json['message']['data']).bytesize
+          end
+
+          # This is a hack. The schema defines `priority` to be an integer, but FCM expects a string.
+          # But for users of rpush to have an API they might expect (setting priority to `high`, not 10)
+          # we do a little conversion here.
+          def priority=(priority)
+            case priority
+            when 'high', FCM_PRIORITY_HIGH
+              super(FCM_PRIORITY_HIGH)
+            when 'normal', FCM_PRIORITY_NORMAL
+              super(FCM_PRIORITY_NORMAL)
+            else
+              errors.add(:priority, 'must be one of either "normal" or "high"')
+            end
+          end
+
+          def dry_run=(value)
+            fail ArgumentError, 'FCM does not support dry run' if value
+          end
+
+          def mutable_content=(value)
+            fail ArgumentError, 'RPush does not currently support mutable_content for FCM' if value
+          end
+
+          def as_json(options = nil) # rubocop:disable Metrics/PerceivedComplexity
+            json = {
+              'data' => data,
+              'android' => android_config,
+              'token' => device_token
+            }
+            # Android does not appear to handle content_available anymore. Instead "priority" should be used
+            # with "low" being a background only message. APN however should support this field.
+            # json['content_available'] = content_available if content_available
+            json['notification'] = root_notification if notification
+            { 'message' => json }
+          end
+
+          def android_config
+            json = {
+              'notification' => android_notification,
+            }
+            json['data'] = data if data
+            json['collapse_key'] = collapse_key if collapse_key
+            json['priority'] = priority_str if priority
+            json['ttl'] = "#{expiry}s" if expiry
+            json
+          end
+
+          def android_notification
+            json = notification || {}
+            json['notification_priority'] = priority_for_notification if priority
+            json['sound'] = sound if sound
+            json['default_sound'] = !sound || sound == 'default' ? true : false
+            json
+          end
+
+          def priority_str
+            case
+            when priority <= 5 then 'normal'
+            else
+              'high'
+            end
+          end
+
+          def priority_for_notification
+            case priority
+            when 0 then 'PRIORITY_UNSPECIFIED'
+            when 1 then 'PRIORITY_MIN'
+            when 2 then 'PRIORITY_LOW'
+            when 5 then 'PRIORITY_DEFAULT'
+            when 6 then 'PRIORITY_HIGH'
+            when 10 then 'PRIORITY_MAX'
+            else
+              'PRIORITY_DEFAULT'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -11,7 +11,7 @@ module Rpush
           ANDROID_NOTIFICATION_KEYS = %w[icon tag color click_action body_loc_key body_loc_args title_loc_key
                                          title_loc_args channel_id ticker sticky event_time local_only
                                          default_vibrate_timings default_light_settings vibrate_timings
-                                         visibility notification_count light_settings].freeze
+                                         visibility notification_count light_settings sound].freeze
 
           def self.included(base)
             base.instance_eval do
@@ -76,8 +76,18 @@ module Rpush
             json
           end
 
+          def notification=(value)
+            super(value.with_indifferent_access)
+          end
+
+          def root_notification
+            return {} unless notification
+
+            notification.slice(*ROOT_NOTIFICATION_KEYS)
+          end
+
           def android_notification
-            json = notification || {}
+            json = notification&.slice(*ANDROID_NOTIFICATION_KEYS) || {}
             json['notification_priority'] = priority_for_notification if priority
             json['sound'] = sound if sound
             json['default_sound'] = !sound || sound == 'default' ? true : false

--- a/lib/rpush/client/active_model/fcm/notification_keys_in_allowed_list_validator.rb
+++ b/lib/rpush/client/active_model/fcm/notification_keys_in_allowed_list_validator.rb
@@ -1,0 +1,20 @@
+module Rpush
+  module Client
+    module ActiveModel
+      module Fcm
+        class NotificationKeysInAllowedListValidator < ::ActiveModel::Validator
+          def validate(record)
+            return unless record.notification
+
+            allowed_keys = Notification::ROOT_NOTIFICATION_KEYS + Notification::ANDROID_NOTIFICATION_KEYS
+            invalid_keys = record.notification.keys - allowed_keys
+
+            return if invalid_keys.empty?
+
+            record.errors.add(:notification, "contains invalid keys: #{invalid_keys.join(', ')}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record.rb
+++ b/lib/rpush/client/active_record.rb
@@ -16,6 +16,9 @@ require 'rpush/client/active_record/apns2/app'
 require 'rpush/client/active_record/apnsp8/notification'
 require 'rpush/client/active_record/apnsp8/app'
 
+require 'rpush/client/active_record/fcm/notification'
+require 'rpush/client/active_record/fcm/app'
+
 require 'rpush/client/active_record/gcm/notification'
 require 'rpush/client/active_record/gcm/app'
 

--- a/lib/rpush/client/active_record/fcm/app.rb
+++ b/lib/rpush/client/active_record/fcm/app.rb
@@ -1,0 +1,11 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Fcm
+        class App < Rpush::Client::ActiveRecord::App
+          include Rpush::Client::ActiveModel::Fcm::App
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/client/active_record/fcm/notification.rb
+++ b/lib/rpush/client/active_record/fcm/notification.rb
@@ -1,0 +1,11 @@
+module Rpush
+  module Client
+    module ActiveRecord
+      module Fcm
+        class Notification < Rpush::Client::ActiveRecord::Notification
+          include Rpush::Client::ActiveModel::Fcm::Notification
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/configuration.rb
+++ b/lib/rpush/configuration.rb
@@ -106,7 +106,7 @@ module Rpush
       client_module = Rpush::Client.const_get(client.to_s.camelize)
       Rpush.send(:include, client_module) unless Rpush.ancestors.include?(client_module)
 
-      [:Apns, :Gcm, :Wpns, :Wns, :Adm, :Pushy, :Webpush].each do |service|
+      [:Apns, :Fcm, :Gcm, :Wpns, :Wns, :Adm, :Pushy, :Webpush].each do |service|
         Rpush.const_set(service, client_module.const_get(service)) unless Rpush.const_defined?(service)
       end
 

--- a/lib/rpush/daemon.rb
+++ b/lib/rpush/daemon.rb
@@ -49,6 +49,9 @@ require 'rpush/daemon/apnsp8/delivery'
 require 'rpush/daemon/apnsp8/token'
 require 'rpush/daemon/apnsp8'
 
+require 'rpush/daemon/fcm/delivery'
+require 'rpush/daemon/fcm'
+
 require 'rpush/daemon/gcm/delivery'
 require 'rpush/daemon/gcm'
 

--- a/lib/rpush/daemon/fcm.rb
+++ b/lib/rpush/daemon/fcm.rb
@@ -1,0 +1,9 @@
+module Rpush
+  module Daemon
+    module Fcm
+      extend ServiceConfigMethods
+
+      dispatcher :http
+    end
+  end
+end

--- a/lib/rpush/daemon/fcm/delivery.rb
+++ b/lib/rpush/daemon/fcm/delivery.rb
@@ -1,0 +1,160 @@
+module Rpush
+  module Daemon
+    module Fcm
+      # https://firebase.google.com/docs/cloud-messaging/server
+      class Delivery < Rpush::Daemon::Delivery
+        include MultiJsonHelper
+
+        HOST = 'https://fcm.googleapis.com'.freeze
+        SCOPE = 'https://www.googleapis.com/auth/firebase.messaging'.freeze
+
+        def initialize(app, http, notification, batch)
+          if necessary_data_exists?
+            @app = app
+            @http = http
+            @notification = notification
+            @batch = batch
+
+            @uri = URI.parse("#{HOST}/v1/projects/#{ENV['FIREBASE_PROJECT_ID']}/messages:send")
+          else
+            Rpush.logger.error("Cannot find necessary configuration! Please make sure you have set all necessary ENV variables!")
+          end
+        end
+
+        def perform
+          handle_response(do_post)
+        rescue SocketError => error
+          mark_retryable(@notification, Time.now + 10.seconds, error)
+          raise
+        rescue StandardError => error
+          mark_failed(error)
+          raise
+        ensure
+          @batch.notification_processed
+        end
+
+        protected
+
+        def handle_response(response)
+          case response.code.to_i
+          when 200
+            ok
+          when 400
+            bad_request(response)
+          when 401
+            unauthorized
+          when 403
+            sender_id_mismatch
+          when 404
+            unregistered(response)
+          when 429
+            too_many_requests
+          when 500
+            internal_server_error(response)
+          when 502
+            bad_gateway(response)
+          when 503
+            service_unavailable(response)
+          when 500..599
+            other_5xx_error(response)
+          else
+            fail Rpush::DeliveryError.new(response.code.to_i, @notification.id, Rpush::Daemon::HTTP_STATUS_CODES[response.code.to_i])
+          end
+        end
+
+        def ok
+          reflect(:fcm_delivered_to_recipient, @notification)
+          mark_delivered
+          log_info("#{@notification.id} sent to #{@notification.device_token}")
+        end
+
+        def bad_request(response)
+          fail Rpush::DeliveryError.new(400, @notification.id, "FCM failed to handle the JSON request. (#{parse_error(response)})")
+        end
+
+        def unauthorized
+          fail Rpush::DeliveryError.new(401, @notification.id, 'Unauthorized, Bearer token could not be validated.')
+        end
+
+        def sender_id_mismatch
+          fail Rpush::DeliveryError.new(403, @notification.id, 'The sender ID was mismatched. It seems the device token is wrong.')
+        end
+
+        def unregistered(response)
+          fail Rpush::DeliveryError.new(404, @notification.id, "Client was not registered for your app. (#{parse_error(response)})")
+        end
+
+        def too_many_requests
+          fail Rpush::DeliveryError.new(429, @notification.id, 'Slow down. Too many requests were sent!')
+        end
+
+        def internal_server_error(response)
+          retry_delivery(@notification, response)
+          log_warn("FCM responded with an Internal Error. " + retry_message)
+        end
+
+        def bad_gateway(response)
+          retry_delivery(@notification, response)
+          log_warn("FCM responded with a Bad Gateway Error. " + retry_message)
+        end
+
+        def service_unavailable(response)
+          retry_delivery(@notification, response)
+          log_warn("FCM responded with an Service Unavailable Error. " + retry_message)
+        end
+
+        def other_5xx_error(response)
+          retry_delivery(@notification, response)
+          log_warn("FCM responded with a 5xx Error. " + retry_message)
+        end
+
+        def parse_error(response)
+          error = multi_json_load(response.body)['error']
+          puts "PARSED: #{error} #{error['message']}"
+          "#{error['status']}: #{error['message']}"
+        end
+
+        def deliver_after_header(response)
+          Rpush::Daemon::RetryHeaderParser.parse(response.header['retry-after'])
+        end
+
+        def retry_delivery(notification, response)
+          time = deliver_after_header(response)
+          if time
+            mark_retryable(notification, time)
+          else
+            mark_retryable_exponential(notification)
+          end
+        end
+
+        def retry_message
+          "Notification #{@notification.id} will be retried after #{@notification.deliver_after.strftime('%Y-%m-%d %H:%M:%S')} (retry #{@notification.retries})."
+        end
+
+        def obtain_access_token
+          authorizer = ::Google::Auth::ServiceAccountCredentials.make_creds(scope: SCOPE)
+          authorizer.fetch_access_token
+        end
+
+        def do_post
+          token = obtain_access_token['access_token']
+          post = Net::HTTP::Post.new(@uri.path, 'Content-Type'  => 'application/json',
+                                     'Authorization' => "Bearer #{token}")
+          post.body = @notification.as_json.to_json
+          @http.request(@uri, post)
+        end
+
+        def necessary_data_exists?
+          # Needed for Google Auth
+          # See https://github.com/googleapis/google-auth-library-ruby#example-environment-variables
+          # for further information
+          ENV.key?('FIREBASE_PROJECT_ID') &&
+            ENV.key?('GOOGLE_ACCOUNT_TYPE') &&
+            ENV.key?('GOOGLE_CLIENT_ID') &&
+            ENV.key?('GOOGLE_CLIENT_EMAIL') &&
+            ENV.key?('GOOGLE_PRIVATE_KEY')
+        end
+      end
+    end
+  end
+end

--- a/lib/rpush/daemon/store/active_record.rb
+++ b/lib/rpush/daemon/store/active_record.rb
@@ -145,6 +145,11 @@ module Rpush
           end
         end
 
+        def create_fcm_notification(attrs, data, app)
+          notification = Rpush::Client::ActiveRecord::Fcm::Notification.new
+          create_fcm_like_notification(notification, attrs, data, app)
+        end
+
         def create_gcm_notification(attrs, data, registration_ids, deliver_after, app)
           notification = Rpush::Client::ActiveRecord::Gcm::Notification.new
           create_gcm_like_notification(notification, attrs, data, registration_ids, deliver_after, app)
@@ -182,6 +187,16 @@ module Rpush
         end
 
         private
+
+        def create_fcm_like_notification(notification, attrs, data, app) # rubocop:disable Metrics/ParameterLists
+          with_database_reconnect_and_retry do
+            notification.assign_attributes(attrs)
+            notification.data = data
+            notification.app = app
+            notification.save!
+            notification
+          end
+        end
 
         def create_gcm_like_notification(notification, attrs, data, registration_ids, deliver_after, app) # rubocop:disable Metrics/ParameterLists
           with_database_reconnect_and_retry do

--- a/lib/rpush/daemon/store/interface.rb
+++ b/lib/rpush/daemon/store/interface.rb
@@ -5,7 +5,7 @@ module Rpush
         PUBLIC_METHODS = [:deliverable_notifications, :mark_retryable,
                           :mark_batch_retryable, :mark_delivered, :mark_batch_delivered,
                           :mark_failed, :mark_batch_failed, :create_apns_feedback,
-                          :create_gcm_notification, :create_adm_notification, :update_app,
+                          :create_fcm_notification, :create_gcm_notification, :create_adm_notification, :update_app,
                           :update_notification, :release_connection,
                           :all_apps, :app, :mark_ids_failed, :mark_ids_retryable,
                           :reopen_log, :pending_delivery_count, :translate_integer_notification_id]

--- a/lib/rpush/reflection_collection.rb
+++ b/lib/rpush/reflection_collection.rb
@@ -6,7 +6,7 @@ module Rpush
       :apns_feedback, :notification_enqueued, :notification_delivered,
       :notification_failed, :notification_will_retry, :gcm_delivered_to_recipient,
       :gcm_failed_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
-      :fcm_delivered_to_recipient, :fcm_failed_to_recipient, :fcm_canonical_id, :fcm_invalid_device_token,
+      :fcm_delivered_to_recipient, :fcm_failed_to_recipient, :fcm_invalid_device_token, :fcm_unauthorized, :fcm_bad_request,
       :error, :adm_canonical_id, :adm_failed_to_recipient, :wns_invalid_channel,
       :tcp_connection_lost, :ssl_certificate_will_expire, :ssl_certificate_revoked,
       :notification_id_will_retry, :notification_id_failed

--- a/lib/rpush/reflection_collection.rb
+++ b/lib/rpush/reflection_collection.rb
@@ -6,6 +6,7 @@ module Rpush
       :apns_feedback, :notification_enqueued, :notification_delivered,
       :notification_failed, :notification_will_retry, :gcm_delivered_to_recipient,
       :gcm_failed_to_recipient, :gcm_canonical_id, :gcm_invalid_registration_id,
+      :fcm_delivered_to_recipient, :fcm_failed_to_recipient, :fcm_canonical_id, :fcm_invalid_device_token,
       :error, :adm_canonical_id, :adm_failed_to_recipient, :wns_invalid_channel,
       :tcp_connection_lost, :ssl_certificate_will_expire, :ssl_certificate_revoked,
       :notification_id_will_retry, :notification_id_failed

--- a/rpush.gemspec
+++ b/rpush.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'rainbow'
   s.add_runtime_dependency 'webpush', '~> 1.0'
+  s.add_runtime_dependency 'googleauth'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.4.0'

--- a/spec/functional/fcm_priority_spec.rb
+++ b/spec/functional/fcm_priority_spec.rb
@@ -1,0 +1,45 @@
+require 'functional_spec_helper'
+
+describe 'FCM priority' do
+  let(:app) { Rpush::Fcm::App.new }
+  let(:notification) { Rpush::Fcm::Notification.new }
+  let(:hydrated_notification) { Rpush::Fcm::Notification.find(notification.id) }
+  let(:response) { double(Net::HTTPResponse, code: 200) }
+  let(:http) { double(Net::HTTP::Persistent, request: response, shutdown: nil) }
+  let(:priority) { 'normal' }
+  let(:fake_device_token) { 'a' * 108 }
+
+  before do
+    app.name = 'test'
+    app.auth_key = 'abc123'
+    app.save!
+
+    notification.app_id = app.id
+    notification.device_token = fake_device_token
+    notification.data = { message: 'test' }
+    notification.priority = priority
+    notification.save!
+
+    allow(Net::HTTP::Persistent).to receive_messages(new: http)
+  end
+
+  it 'supports normal priority' do
+    json = hydrated_notification.as_json
+    expect(json["message"]["android"]["notification"]["notification_priority"]).to eq('PRIORITY_DEFAULT')
+    expect(json["message"]["android"]["priority"]).to eq('normal')
+  end
+
+  context 'high priority' do
+    let(:priority) { 'high' }
+
+    it 'supports high priority' do
+      json = hydrated_notification.as_json
+      expect(json["message"]["android"]["notification"]["notification_priority"]).to eq('PRIORITY_MAX')
+      expect(json["message"]["android"]["priority"]).to eq('high')
+    end
+  end
+
+  it 'does not add an error when receiving expected priority' do
+    expect(hydrated_notification.errors.messages[:priority]).to be_empty
+  end
+end

--- a/spec/functional/fcm_spec.rb
+++ b/spec/functional/fcm_spec.rb
@@ -1,0 +1,77 @@
+require 'functional_spec_helper'
+
+describe 'FCM' do
+  let(:app) { Rpush::Fcm::App.new }
+  let(:notification) { Rpush::Fcm::Notification.new }
+  let(:response) { double(Net::HTTPResponse, code: 200) }
+  let(:http) { double(Net::HTTP::Persistent, request: response, shutdown: nil) }
+  let(:fake_device_token) { 'a' * 108 }
+  let(:creds) {double(Google::Auth::UserRefreshCredentials)}
+
+  before do
+    app.name = 'test'
+    app.auth_key = 'abc123'
+    app.save!
+
+    notification.app_id = app.id
+    notification.device_token = fake_device_token
+    notification.data = { message: 'test' }
+    notification.save!
+
+    allow(Net::HTTP::Persistent).to receive_messages(new: http)
+    allow(creds).to receive(:fetch_access_token).and_return({'access_token': 'face_access_token'})
+
+    allow(::Google::Auth::ServiceAccountCredentials).to receive(:fetch_access_token).and_return({access_token: 'bbbbbb'})
+    allow(::Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(creds)
+    allow_any_instance_of(::Rpush::Daemon::Fcm::Delivery).to receive(:necessary_data_exists?).and_return(true)
+  end
+
+  it 'delivers a notification successfully' do
+    example_success_body = {
+      "multicast_id": 108,
+      "success": 1,
+      "failure": 0,
+      "canonical_ids": 0,
+      "results": [
+        { "message_id": "1:08" }
+      ]
+    }.to_json
+    allow(response).to receive_messages(body: example_success_body)
+
+    expect do
+      Rpush.push
+      notification.reload
+    end.to change(notification, :delivered).to(true)
+  end
+
+  it 'fails to deliver a notification successfully' do
+    example_error_body = {
+      "error": {
+        "code": 400,
+        "message": "The registration token is not a valid FCM registration token",
+        "errors": [
+          {
+            "message": "The registration token is not a valid FCM registration token",
+            "domain": "global",
+            "reason": "badRequest"
+          }
+        ],
+        "status": "INVALID_ARGUMENT"
+      }
+    }.to_json
+
+    allow(response).to receive_messages(code: 400, body: example_error_body)
+    Rpush.push
+    notification.reload
+    expect(notification.delivered).to eq(false)
+  end
+
+  it 'retries notification that fail due to a SocketError' do
+    expect(http).to receive(:request).and_raise(SocketError.new)
+    expect(notification.deliver_after).to be_nil
+    expect do
+      Rpush.push
+      notification.reload
+    end.to change(notification, :deliver_after).to(kind_of(Time))
+  end
+end

--- a/spec/unit/client/active_record/fcm/app_spec.rb
+++ b/spec/unit/client/active_record/fcm/app_spec.rb
@@ -1,0 +1,6 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::ActiveRecord::Fcm::App do
+  it_behaves_like 'Rpush::Client::Fcm::App'
+  it_behaves_like 'Rpush::Client::ActiveRecord::App'
+end if active_record?

--- a/spec/unit/client/active_record/fcm/notification_spec.rb
+++ b/spec/unit/client/active_record/fcm/notification_spec.rb
@@ -1,0 +1,10 @@
+require 'unit_spec_helper'
+
+describe Rpush::Client::ActiveRecord::Fcm::Notification do
+  it_behaves_like 'Rpush::Client::Fcm::Notification'
+  it_behaves_like 'Rpush::Client::ActiveRecord::Notification'
+
+  subject(:notification) { described_class.new }
+  let(:app) { Rpush::Fcm::App.create!(name: 'test', auth_key: 'abc') }
+
+end if active_record?

--- a/spec/unit/client/shared/fcm/app.rb
+++ b/spec/unit/client/shared/fcm/app.rb
@@ -1,0 +1,4 @@
+require 'unit_spec_helper'
+
+shared_examples 'Rpush::Client::Fcm::App' do
+end

--- a/spec/unit/client/shared/fcm/notification.rb
+++ b/spec/unit/client/shared/fcm/notification.rb
@@ -1,0 +1,94 @@
+require 'unit_spec_helper'
+
+shared_examples 'Rpush::Client::Fcm::Notification' do
+  let(:app) { Rpush::Fcm::App.create!(name: 'test', auth_key: 'abc') }
+  let(:notification) { described_class.new }
+
+  it "has a 'data' payload limit of 4096 bytes" do
+    notification.app = app
+    notification.device_token = "valid"
+    notification.data = { key: "a" * 4096 }
+    expect(notification.valid?).to be_falsey
+    expect(notification.errors[:base]).to eq ["Notification payload data cannot be larger than 4096 bytes."]
+  end
+
+  it "validates notification keys" do
+    notification.app = app
+    notification.device_token = "valid"
+    notification.notification = { "title" => "valid", "body" => "valid", "color" => "valid for android", "garbage" => "invalid" }
+    expect(notification.valid?).to be_falsey
+    expect(notification.errors[:notification]).to eq ["contains invalid keys: garbage"]
+  end
+
+  it "allows notifications with either symbol keys or string keys" do
+    notification.app = app
+    notification.notification = { "title" => "title", body: "body" }
+    expect(notification.as_json['message']['notification']).to eq({"title"=>"title", "body"=>"body"})
+  end
+
+  it "moves notification keys to the correcdt location" do
+    notification.app = app
+    notification.device_token = "valid"
+    notification.notification = { "title" => "valid", "body" => "valid", "color" => "valid for android" }
+    expect(notification.valid?).to be_truthy
+    expect(notification.as_json['message']['notification']).to eq("title"=>"valid", "body"=>"valid")
+    expect(notification.as_json['message']['android']['notification']['color']).to eq('valid for android')
+  end
+
+  it 'validates expiry is present if collapse_key is set' do
+    notification.collapse_key = 'test'
+    notification.expiry = nil
+    expect(notification.valid?).to be_falsey
+    expect(notification.errors[:expiry]).to eq ['must be set when using a collapse_key']
+  end
+
+  it 'includes time_to_live in the payload' do
+    notification.expiry = 100
+    expect(notification.as_json['message']['android']['ttl']).to eq '100s'
+  end
+
+  it 'includes content_available in the payload' do
+    notification.content_available = true
+    expect(notification.as_json['message']['content_available']).to eq true
+  end
+
+  it 'fails if mutable_content is provided' do
+    expect { notification.mutable_content = true }.to raise_error(ArgumentError)
+  end
+
+  it 'sets the priority to high when set to high' do
+    notification.priority = 'high'
+    expect(notification.as_json['message']['android']['priority']).to eq 'high'
+    expect(notification.as_json['message']['android']['notification']['notification_priority']).to eq 'PRIORITY_MAX'
+    # TODO Add notification_priority
+  end
+
+  it 'sets the priority to normal when set to normal' do
+    notification.priority = 'normal'
+    expect(notification.as_json['message']['android']['priority']).to eq 'normal'
+    expect(notification.as_json['message']['android']['notification']['notification_priority']).to eq 'PRIORITY_DEFAULT'
+    # TODO Add notification_priority
+  end
+
+  it 'validates the priority is either "normal" or "high"' do
+    notification.priority = 'invalid'
+    expect(notification.errors[:priority]).to eq ['must be one of either "normal" or "high"']
+  end
+
+  it 'excludes the priority if it is not defined' do
+    expect(notification.as_json['message']['android']).not_to have_key 'priority'
+  end
+
+  it 'includes the notification payload if defined' do
+    notification.notification = { key: 'any key is allowed' }
+    expect(notification.as_json['message']).to have_key 'notification'
+  end
+
+  it 'excludes the notification payload if undefined' do
+    expect(notification.as_json['message']).not_to have_key 'notification'
+  end
+
+  it 'fails when trying to set the dry_run option' do
+    expect { notification.dry_run = true }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/unit/daemon/fcm/delivery_spec.rb
+++ b/spec/unit/daemon/fcm/delivery_spec.rb
@@ -1,0 +1,127 @@
+require 'unit_spec_helper'
+
+describe Rpush::Daemon::Fcm::Delivery do
+  let(:app) { Rpush::Fcm::App.create!(name: 'MyApp', firebase_project_id: 'abc123', json_key:'{}') }
+  let(:notification) { Rpush::Fcm::Notification.create!(app: app, device_token: 'xyz', deliver_after: Time.now) }
+  let(:logger) { double(error: nil, info: nil, warn: nil) }
+  let(:response) { double(code: 200, header: {}) }
+  let(:http) { double(shutdown: nil, request: response) }
+  let(:now) { Time.parse('2012-10-14 00:00:00') }
+  let(:batch) { double(mark_failed: nil, mark_delivered: nil, mark_retryable: nil, notification_processed: nil) }
+  let(:delivery) { Rpush::Daemon::Fcm::Delivery.new(app, http, notification, batch) }
+  let(:store) { double(create_fcm_notification: double(id: 2)) }
+
+  def perform
+    delivery.perform
+  end
+
+  def perform_with_rescue
+    expect { perform }.to raise_error(StandardError)
+  end
+
+  before do
+    allow(delivery).to receive_messages(reflect: nil)
+    allow(Rpush::Daemon).to receive_messages(store: store)
+    allow(Time).to receive_messages(now: now)
+    allow(Rpush).to receive_messages(logger: logger)
+    allow_any_instance_of(Rpush::Daemon::Fcm::Delivery).to receive_messages(obtain_access_token: "access_token")
+  end
+
+  describe 'a 200 response' do
+    before do
+      allow(response).to receive_messages(code: 200)
+      allow(response).to receive_messages(body: nil)
+      allow(notification).to receive_messages(device_token: '1')
+    end
+
+    it 'reflects on ID which successfully received the notification' do
+      expect(delivery).to receive(:reflect).with(:fcm_delivered_to_recipient, notification)
+      perform
+    end
+
+    it 'marks the notification as delivered' do
+      expect(delivery).to receive(:mark_delivered)
+      perform
+    end
+
+    it 'logs that the notification was delivered' do
+      expect(logger).to receive(:info).with("[MyApp] #{notification.id} sent to 1")
+      perform
+    end
+  end
+
+  describe 'all deliveries failed with Unavailable or InternalServerError 503' do
+    before do
+      allow(notification).to receive_messages(device_token: '1')
+      allow(response).to receive_messages(code: 503, body: nil)
+    end
+
+    it 'reflects on any IDs which failed to receive the notification' do
+      pending("Determine the correct cases where FCM should send fcm_failed_to_recipient")
+      expect(delivery).to receive(:reflect).with(:fcm_failed_to_recipient, notification)
+      perform
+    end
+
+    it 'retries the notification respecting the Retry-After header' do
+      allow(response).to receive_messages(header: { 'retry-after' => 10 })
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 10.seconds)
+      perform
+    end
+
+    it 'retries the notification using exponential back-off if the Retry-After header is not present' do
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 2)
+      perform
+    end
+
+    it 'does not mark the notification as failed' do
+      expect(delivery).not_to receive(:mark_failed)
+      perform
+    end
+
+    it 'logs that the notification will be retried' do
+      notification.retries = 1
+      notification.deliver_after = now + 2
+      expect(Rpush.logger).to receive(:warn).with("[MyApp] FCM responded with an Service Unavailable Error. Notification #{notification.id} will be retried after 2012-10-14 00:00:02 (retry 1).")
+      perform
+    end
+  end
+
+  describe 'all deliveries failed with Unavailable or InternalServerError 500' do
+    before do
+      allow(notification).to receive_messages(device_token: '1')
+      allow(response).to receive_messages(code: 500, body: nil)
+    end
+
+    it 'logs a warning that the notification has been re-queued.' do
+      notification.retries = 3
+      notification.deliver_after = now + 2**3
+      expect(Rpush.logger).to receive(:warn).with("[MyApp] FCM responded with an Internal Error. Notification #{notification.id} will be retried after #{(now + 2**3).strftime('%Y-%m-%d %H:%M:%S')} (retry 3).")
+      perform
+    end
+
+    it 'retries the notification in accordance with the exponential back-off strategy.' do
+      notification.update_attribute(:retries, 2)
+      expect(delivery).to receive(:mark_retryable).with(notification, now + 2**3)
+      perform
+    end
+  end
+
+  describe 'all deliveries failed with invalid token' do
+    before do
+      allow(notification).to receive_messages(device_token: '1')
+      allow(response).to receive_messages(code: 404, body: { error: { status: 'NOT_FOUND', message: 'Requested entity was not found.' } }.to_json)
+    end
+
+    it 'reflects on invalid IDs' do
+      expect(delivery).to receive(:reflect).with(:fcm_invalid_device_token, app, "NOT_FOUND: Requested entity was not found.", '1')
+      perform_with_rescue
+    end
+
+    it 'marks a notification as failed if any ids are invalid' do
+      expect(delivery).to receive(:mark_failed)
+      expect(delivery).not_to receive(:mark_retryable)
+      expect(store).not_to receive(:create_fcm_notification)
+      perform_with_rescue
+    end
+  end
+end


### PR DESCRIPTION
This PR: in progress
- follow https://github.com/rpush/rpush/pull/620 and https://github.com/rpush/rpush/pull/660 to implement fcm to the rpush gem
- only handle fcm for active record (not radis)
- use token from app (will need to be manually create)
- web pr: https://github.com/Codefied/housecall-web/pull/51310
- jira: https://housecall.atlassian.net/browse/JS-7167